### PR TITLE
Allow newer JDKs to be used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,4 +20,9 @@ allprojects {
         google()
         jcenter()
     }
+
+    // Avoid warning message from newer JDKs about Java 7 source/target being obsolete
+    tasks.withType(JavaCompile).whenTaskAdded { JavaCompile javaCompile ->
+        javaCompile.options.compilerArgs << '-Xlint:-options'
+    }
 }


### PR DESCRIPTION
The latest JDKs all complain with:
    warning: [options] source value 7 is obsolete and will be removed in a future release
    warning: [options] target value 7 is obsolete and will be removed in a future release
    warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.

And to make matters even more annoying, it happens for 4-tasks, so you get 12 total warnings every time you build.

Before issuing a pull request, please see the contributing page.
