### PR TITLE
Fix deprecation warnings (migrate Preferences to androidx)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+
+*.hprof

--- a/FtcRobotController/build.gradle
+++ b/FtcRobotController/build.gradle
@@ -14,7 +14,9 @@ android {
         buildConfigField "String", "APP_BUILD_TIME", '"' + (new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.ROOT).format(new Date())) + '"'
     }
 
-    compileSdkVersion 29
+    // androidx.preferences compatibility
+    // you may need to download sdk 31 support libraries
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7

--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
@@ -40,12 +40,13 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.graphics.Color;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -53,7 +54,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.WindowManager;
 import android.webkit.WebView;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
@@ -531,7 +531,7 @@ public class FtcRobotControllerActivity extends Activity
 
     if (hasFocus) {
       immersion.hideSystemUI();
-      getWindow().setFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION, WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+      getWindow().setNavigationBarColor(Color.TRANSPARENT);
     }
   }
 

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -21,7 +21,9 @@ apply plugin: 'com.android.application'
 
 android {
 
-    compileSdkVersion 29
+    // androidx.preferences compatibility
+    // you may need to download sdk 31 support libraries
+    compileSdkVersion 31
 
     signingConfigs {
         release {

--- a/build.dependencies.gradle
+++ b/build.dependencies.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation 'org.firstinspires.ftc:FtcCommon:7.2.0'
     implementation 'org.tensorflow:tensorflow-lite-task-vision:0.2.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.preference:preference:1.2.0'
     implementation 'org.firstinspires.ftc:gameAssets-FreightFrenzy:1.0.0'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,6 @@ android.useAndroidX=true
 
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+
+# Increase memory capacity for Gradle. (don't crash)
+org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
Switches PreferenceManager to use `androidx.preference` instead of `android.preference` as the latter is deprecated.
As a side effect, the compiler SDK version was increased to 31.

In gradle.properties, jvmargs were configured to use 2048mb RAM for builds (builds were crashing due to OutOfMemoryError)
Fixes #305