### PR TITLE
Arm and claw sync and Direction fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ captures/
 
 # IntelliJ
 *.iml
+.idea/
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/gradle.xml

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -1,0 +1,112 @@
+/* Copyright (c) 2017 FIRST. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted (subject to the limitations in the disclaimer below) provided that
+ * the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of FIRST nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS
+ * LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.qualcomm.robotcore.hardware.DistanceSensor;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+import com.qualcomm.robotcore.hardware.TouchSensor;
+
+/**
+ * This is NOT an opmode.
+ * <p>
+ * This class can be used to define all the specific hardware for the robot.
+ * <p>
+ */
+public class HuskyBot {
+    /* Public OpMode members. */
+    public DcMotorEx frontLeftDrive = null;
+    public DcMotorEx frontRightDrive = null;
+    public DcMotorEx rearLeftDrive = null;
+    public DcMotorEx rearRightDrive = null;
+
+    // goBILDA 5203 Series Yellow Jacket Planetary Gear Motor
+    // max encoder ticks per second
+    // https://www.gobilda.com/5203-series-yellow-jacket-planetary-gear-motor-19-2-1-ratio-24mm-length-8mm-rex-shaft-312-rpm-3-3-5v-encoder/
+    public static final double VELOCITY_CONSTANT = 537.7 * 312/60;
+
+    /* local OpMode members. */
+    HardwareMap hwMap = null;
+
+    public HuskyBot() {
+
+    }
+
+    /* Initialize standard Hardware interfaces */
+    public void init(HardwareMap ahwMap) {
+        // Save reference to Hardware map
+        hwMap = ahwMap;
+
+        // Define and Initialize Motors
+        frontLeftDrive = hwMap.get(DcMotorEx.class, "front_left_drive");
+        rearLeftDrive = hwMap.get(DcMotorEx.class, "rear_left_drive");
+        frontRightDrive = hwMap.get(DcMotorEx.class, "front_right_drive");
+        rearRightDrive = hwMap.get(DcMotorEx.class, "rear_right_drive");
+
+        frontLeftDrive.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+        rearLeftDrive.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+        frontRightDrive.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+        rearRightDrive.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+
+        frontLeftDrive.setDirection(DcMotor.Direction.REVERSE);
+        rearLeftDrive.setDirection(DcMotor.Direction.REVERSE);
+
+        // Set all motors to zero power
+        frontLeftDrive.setPower(0);
+        rearLeftDrive.setPower(0);
+        frontRightDrive.setPower(0);
+        rearRightDrive.setPower(0);
+
+        // this base configuration sets the drive motors to run without encoders and the arm motor
+        // to run with encoder. if any opmode requires different setting, that should be changed in
+        // the opmode itself
+        frontLeftDrive.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        frontRightDrive.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        rearLeftDrive.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        rearRightDrive.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+
+        frontLeftDrive.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rearLeftDrive.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        frontRightDrive.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rearRightDrive.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+
+        // https://docs.google.com/document/u/1/d/1tyWrXDfMidwYyP_5H4mZyVgaEswhOC35gvdmP-V-5hA/mobilebasic
+        // todo these still need to be tuned
+        frontLeftDrive.setVelocityPIDFCoefficients(1.82, 0.182, 0, 18.2);
+        frontLeftDrive.setPositionPIDFCoefficients(5.0);
+        rearLeftDrive.setVelocityPIDFCoefficients(1.18, 0.118, 0, 11.8);
+        rearLeftDrive.setPositionPIDFCoefficients(5.0);
+        frontRightDrive.setVelocityPIDFCoefficients(1.43, 0.143, 0, 14.3);
+        frontRightDrive.setPositionPIDFCoefficients(5.0);
+        rearRightDrive.setVelocityPIDFCoefficients(1.27, 0.127, 0, 12.7);
+        rearRightDrive.setPositionPIDFCoefficients(5.0);
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -31,9 +31,7 @@ package org.firstinspires.ftc.teamcode;
 
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
-import com.qualcomm.robotcore.hardware.DistanceSensor;
 import com.qualcomm.robotcore.hardware.HardwareMap;
-import com.qualcomm.robotcore.hardware.TouchSensor;
 
 /**
  * This is NOT an opmode.
@@ -48,7 +46,7 @@ public class HuskyBot {
     public DcMotorEx rearLeftDrive = null;
     public DcMotorEx rearRightDrive = null;
 
-    public DcMotorEx armSwivelMotor = null;
+    public DcMotorEx armSwivel = null;
 
     // goBILDA 5203 Series Yellow Jacket Planetary Gear Motor
     // max encoder ticks per second
@@ -73,8 +71,7 @@ public class HuskyBot {
         frontRightDrive = hwMap.get(DcMotorEx.class, "front_right_drive");
         rearRightDrive = hwMap.get(DcMotorEx.class, "rear_right_drive");
 
-        // todo: add device name for Arm Motor [THIS NEEDS TO BE DONE BEFORE WE RUN THE PROGRAM]
-        armSwivelMotor = hwMap.get(DcMotorEx.class, "");
+        armSwivel = hwMap.get(DcMotorEx.class, "arm_swivel");
 
 
         frontLeftDrive.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -117,6 +117,9 @@ public class HuskyBot {
         armLift.setPower(0);
         armExtend.setPower(0);
 
+        clawGrab.setPosition(0.7);
+        clawLift.setPosition(0);
+        clawRotate.setPosition(0);
         // this base configuration sets the drive motors to run without encoders and the arm motor
         // to run with encoder. if any opmode requires different setting, that should be changed in
         // the opmode itself

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -48,6 +48,8 @@ public class HuskyBot {
     public DcMotorEx rearLeftDrive = null;
     public DcMotorEx rearRightDrive = null;
 
+    public DcMotorEx armSwivelMotor = null;
+
     // goBILDA 5203 Series Yellow Jacket Planetary Gear Motor
     // max encoder ticks per second
     // https://www.gobilda.com/5203-series-yellow-jacket-planetary-gear-motor-19-2-1-ratio-24mm-length-8mm-rex-shaft-312-rpm-3-3-5v-encoder/
@@ -70,6 +72,10 @@ public class HuskyBot {
         rearLeftDrive = hwMap.get(DcMotorEx.class, "rear_left_drive");
         frontRightDrive = hwMap.get(DcMotorEx.class, "front_right_drive");
         rearRightDrive = hwMap.get(DcMotorEx.class, "rear_right_drive");
+
+        // todo: add device name for Arm Motor [THIS NEEDS TO BE DONE BEFORE WE RUN THE PROGRAM]
+        armSwivelMotor = hwMap.get(DcMotorEx.class, "");
+
 
         frontLeftDrive.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
         rearLeftDrive.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -32,6 +32,7 @@ package org.firstinspires.ftc.teamcode;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
+import com.qualcomm.robotcore.hardware.Servo;
 
 /**
  * This is NOT an opmode.
@@ -46,7 +47,15 @@ public class HuskyBot {
     public DcMotorEx rearLeftDrive = null;
     public DcMotorEx rearRightDrive = null;
 
+    // Arm Control Motor Init.
     public DcMotorEx armSwivel = null;
+    public DcMotorEx armHeight = null;
+    public DcMotorEx armLength = null;
+
+    // Claw (on the Arm) Servo Init.
+    public Servo clawHeight = null;
+    public Servo clawAngle = null;
+    public Servo clawOpener = null; // TODO: set this to be fixed open/close positions.
 
     // goBILDA 5203 Series Yellow Jacket Planetary Gear Motor
     // max encoder ticks per second
@@ -71,7 +80,15 @@ public class HuskyBot {
         frontRightDrive = hwMap.get(DcMotorEx.class, "front_right_drive");
         rearRightDrive = hwMap.get(DcMotorEx.class, "rear_right_drive");
 
+        // Define and Init. Arm Motors
         armSwivel = hwMap.get(DcMotorEx.class, "arm_swivel");
+        armHeight = hwMap.get(DcMotorEx.class, "arm_height");
+        armLength = hwMap.get(DcMotorEx.class, "arm_length");
+
+        // Define and Init. Claw Servos
+        clawAngle = hwMap.get(Servo.class, "claw_angle");
+        clawHeight = hwMap.get(Servo.class, "claw_height");
+        clawOpener = hwMap.get(Servo.class, "claw_opener");
 
 
         frontLeftDrive.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
@@ -87,6 +104,11 @@ public class HuskyBot {
         rearLeftDrive.setPower(0);
         frontRightDrive.setPower(0);
         rearRightDrive.setPower(0);
+
+        // Set all arm-related motors and servos to zero power.
+        armSwivel.setPower(0);
+        armHeight.setPower(0);
+        armLength.setPower(0);
 
         // this base configuration sets the drive motors to run without encoders and the arm motor
         // to run with encoder. if any opmode requires different setting, that should be changed in

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -63,10 +63,11 @@ public class HuskyBot {
     public static final double VELOCITY_CONSTANT = 537.7 * 312/60;
 
 
-    public static final double ARM_SWIVEL_MAX_POWER = 0.2;
+    public static final double ARM_SWIVEL_MAX_POWER = 0.4;
     public static final double ARM_SWIVEL_LIMIT = 200;
-    public static final double ARM_LIFT_MAX_POWER = 0.2;
-    public static final double ARM_EXTENSION_MAX_POWER = 0.2;
+    public static final double ARM_LIFT_MAX_POWER = 0.4;
+    public static final double ARM_LIFT_POWER_AT_REST = 0.1;
+    public static final double ARM_EXTENSION_MAX_POWER = 0.4;
 
     /* local OpMode members. */
     HardwareMap hwMap = null;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -49,18 +49,24 @@ public class HuskyBot {
 
     // Arm Control Motor Init.
     public DcMotorEx armSwivel = null;
-    public DcMotorEx armHeight = null;
-    public DcMotorEx armLength = null;
+    public DcMotorEx armLift = null;
+    public DcMotorEx armExtend = null;
 
     // Claw (on the Arm) Servo Init.
-    public Servo clawHeight = null;
-    public Servo clawAngle = null;
-    public Servo clawOpener = null; // TODO: set this to be fixed open/close positions.
+    public Servo clawLift = null;
+    public Servo clawRotate = null;
+    public Servo clawGrab = null; // TODO: set this to be fixed open/close positions.
 
     // goBILDA 5203 Series Yellow Jacket Planetary Gear Motor
     // max encoder ticks per second
     // https://www.gobilda.com/5203-series-yellow-jacket-planetary-gear-motor-19-2-1-ratio-24mm-length-8mm-rex-shaft-312-rpm-3-3-5v-encoder/
     public static final double VELOCITY_CONSTANT = 537.7 * 312/60;
+
+
+    public static final double ARM_SWIVEL_MAX_POWER = 0.2;
+    public static final double ARM_SWIVEL_LIMIT = 200;
+    public static final double ARM_LIFT_MAX_POWER = 0.2;
+    public static final double ARM_EXTENSION_MAX_POWER = 0.2;
 
     /* local OpMode members. */
     HardwareMap hwMap = null;
@@ -82,13 +88,13 @@ public class HuskyBot {
 
         // Define and Init. Arm Motors
         armSwivel = hwMap.get(DcMotorEx.class, "arm_swivel");
-        armHeight = hwMap.get(DcMotorEx.class, "arm_height");
-        armLength = hwMap.get(DcMotorEx.class, "arm_length");
+        armLift = hwMap.get(DcMotorEx.class, "arm_lift");
+        armExtend = hwMap.get(DcMotorEx.class, "arm_extend");
 
         // Define and Init. Claw Servos
-        clawAngle = hwMap.get(Servo.class, "claw_angle");
-        clawHeight = hwMap.get(Servo.class, "claw_height");
-        clawOpener = hwMap.get(Servo.class, "claw_opener");
+        clawRotate = hwMap.get(Servo.class, "claw_rotate");
+        clawLift = hwMap.get(Servo.class, "claw_lift");
+        clawGrab = hwMap.get(Servo.class, "claw_grab");
 
 
         frontLeftDrive.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
@@ -107,8 +113,8 @@ public class HuskyBot {
 
         // Set all arm-related motors and servos to zero power.
         armSwivel.setPower(0);
-        armHeight.setPower(0);
-        armLength.setPower(0);
+        armLift.setPower(0);
+        armExtend.setPower(0);
 
         // this base configuration sets the drive motors to run without encoders and the arm motor
         // to run with encoder. if any opmode requires different setting, that should be changed in

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -1,0 +1,114 @@
+/* Copyright (c) 2017 FIRST. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted (subject to the limitations in the disclaimer below) provided that
+ * the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of FIRST nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS
+ * LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.util.ElapsedTime;
+import com.qualcomm.robotcore.util.Range;
+
+import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
+
+@TeleOp(name = "Husky TeleOpMode", group = "TeleOp")
+public class HuskyTeleOpMode extends LinearOpMode {
+
+    private ElapsedTime runtime = new ElapsedTime();
+
+    HuskyBot huskyBot = new HuskyBot();
+
+    final double END_GAME_TIME = 80.0;  // last 40 seconds
+    final double FINAL_TIME = 110.0;    // last 10 seconds
+    boolean endGameRumbled = false;
+    boolean finalRumbled = false;
+
+    @Override
+    public void runOpMode() {
+        huskyBot.init(hardwareMap);
+
+        telemetry.addData("Status", "Initialized");
+        telemetry.update();
+
+        waitForStart();
+        runtime.reset();
+
+        double y, x, rx;
+
+        // run until the end of the match (driver presses STOP)
+        while (opModeIsActive()) {
+            if ((runtime.seconds() > END_GAME_TIME) && !endGameRumbled)  {
+                gamepad1.rumble(1000);
+                endGameRumbled = true;
+            }
+
+            if ((runtime.seconds() > FINAL_TIME) && !finalRumbled)  {
+                gamepad1.rumble(1000);
+                finalRumbled = true;
+            }
+
+            // drive mechanism
+            y = -gamepad1.left_stick_y; // Remember, this is reversed!
+            x = gamepad1.left_stick_x;
+            rx = gamepad1.right_stick_x;
+
+            // this allows gamepad2 driver to drive the robot at a slower speed, to fine tune
+            // the position of the robot when delivering the cargo
+            y -= 0.3 * (gamepad2.left_stick_y);
+            y = Range.clip(y, -1, 1);
+            x += 0.3 * (gamepad2.left_stick_x);
+            x = Range.clip(x, -1, 1);
+            rx += 0.3 * (gamepad2.right_stick_x);
+            rx = Range.clip(rx, -1, 1);
+
+            double frontLeftVelocity = (y + x + rx) * HuskyBot.VELOCITY_CONSTANT;
+            double rearLeftVelocity = (y - x + rx) * HuskyBot.VELOCITY_CONSTANT;
+            double frontRightVelocity = (y - x - rx) * HuskyBot.VELOCITY_CONSTANT;
+            double rearRightVelocity = (y + x - rx) * HuskyBot.VELOCITY_CONSTANT;
+
+            // apply the calculated values to the motors.
+            huskyBot.frontLeftDrive.setVelocity(frontLeftVelocity);
+            huskyBot.rearLeftDrive.setVelocity(rearLeftVelocity);
+            huskyBot.frontRightDrive.setVelocity(frontRightVelocity);
+            huskyBot.rearRightDrive.setVelocity(rearRightVelocity);
+
+            // Show the elapsed game time and wheel power.
+            telemetry.addData("Status", "Run Time: " + runtime.toString());
+            telemetry.addData("Stick", "y (%.2f), x (%.2f), rx (%.2f)", y, x, rx);
+            telemetry.addData("Actual Vel", "fl (%.2f), rl (%.2f)", huskyBot.frontLeftDrive.getVelocity(), huskyBot.rearLeftDrive.getVelocity());
+            telemetry.addData("Actual Vel", "fr (%.2f), rr (%.2f)", huskyBot.frontRightDrive.getVelocity(), huskyBot.rearRightDrive.getVelocity());
+            telemetry.addData("Target Vel", "fl (%.2f), rl (%.2f)", frontLeftVelocity, rearLeftVelocity);
+            telemetry.addData("Target Vel", "fr (%.2f), rr (%.2f)", frontRightVelocity, rearRightVelocity);
+            telemetry.addData("Power", "front left (%.2f), rear left (%.2f)", huskyBot.frontLeftDrive.getPower(), huskyBot.rearLeftDrive.getPower());
+            telemetry.addData("Power", "front right (%.2f), rear right (%.2f)",  huskyBot.frontLeftDrive.getPower(), huskyBot.rearLeftDrive.getPower());
+
+            telemetry.update();
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -57,7 +57,7 @@ public class HuskyTeleOpMode extends LinearOpMode {
         waitForStart();
         runtime.reset();
 
-        double y, x, rx, armAngle;
+        double y, x, rx;
 
         // run until the end of the match (driver presses STOP)
         while (opModeIsActive()) {
@@ -76,29 +76,41 @@ public class HuskyTeleOpMode extends LinearOpMode {
             x = gamepad1.left_stick_x;
             rx = gamepad1.right_stick_x;
 
-            /* This is commented out to test Gamepad 2 with Arm Movements
-               todo: change this for the final functions
-            // this allows gamepad2 driver to drive the robot at a slower speed, to fine tune
-            // the position of the robot when delivering the cargo
-            y -= 0.3 * (gamepad2.left_stick_y);
-            y = Range.clip(y, -1, 1);
-            x += 0.3 * (gamepad2.left_stick_x);
-            x = Range.clip(x, -1, 1);
-            rx += 0.3 * (gamepad2.right_stick_x);
-            rx = Range.clip(rx, -1, 1);
-            */
-
-            huskyBot.armSwivel.setMode(DcMotor.RunMode.RUN_TO_POSITION);
-            double armPower = -gamepad2.right_stick_x;
-            armPower = Range.clip(armPower, -0.1, 0.35);
-            huskyBot.armSwivel.setPower(armPower);
-            // todo + IMPORTANT: we will have to limit this to rotate only 360 degrees once the arm is added.
-
 
             double frontLeftVelocity = (y + x + rx) * HuskyBot.VELOCITY_CONSTANT;
             double rearLeftVelocity = (y - x + rx) * HuskyBot.VELOCITY_CONSTANT;
             double frontRightVelocity = (y - x - rx) * HuskyBot.VELOCITY_CONSTANT;
             double rearRightVelocity = (y + x - rx) * HuskyBot.VELOCITY_CONSTANT;
+
+            // arm/claw mechanisms
+
+            // todo + IMPORTANT: we will have to limit this to rotate only 360 degrees once the arm is added.
+            double armSwivelPower = -gamepad2.right_stick_x;
+            armSwivelPower = Range.clip(armSwivelPower, -0.65, 0.65);
+
+            double armHeightPower = gamepad2.right_stick_y;
+            // todo: this will have to be tuned for stability
+            armHeightPower = Range.clip(armHeightPower, -0.4, 0.4);
+
+            // Increases/Decreases Arm Length
+            if(gamepad2.dpad_up)
+            {
+                huskyBot.armLength.setPower(0.75);
+            }
+
+            if(gamepad2.dpad_down)
+            {
+                huskyBot.armLength.setPower(-0.75);
+            }
+
+            /*
+            if(gamepad2.a)
+            {
+                // todo get this working so that way it does the entire action and then stops when claw is open
+            }
+            */
+
+
 
             // apply the calculated values to the motors.
             huskyBot.frontLeftDrive.setVelocity(frontLeftVelocity);
@@ -106,8 +118,12 @@ public class HuskyTeleOpMode extends LinearOpMode {
             huskyBot.frontRightDrive.setVelocity(frontRightVelocity);
             huskyBot.rearRightDrive.setVelocity(rearRightVelocity);
 
+            // apply calculated values to arm/claw motors/servos
+            huskyBot.armSwivel.setPower(armSwivelPower);
+            huskyBot.armHeight.setPower(armHeightPower);
 
-            // Show the elapsed game time and wheel power.
+
+            // Show the elapsed game time and wheel power
             telemetry.addData("Status", "Run Time: " + runtime.toString());
             telemetry.addData("Stick", "y (%.2f), x (%.2f), rx (%.2f)", y, x, rx);
             telemetry.addData("Actual Vel", "fl (%.2f), rl (%.2f)", huskyBot.frontLeftDrive.getVelocity(), huskyBot.rearLeftDrive.getVelocity());
@@ -116,6 +132,11 @@ public class HuskyTeleOpMode extends LinearOpMode {
             telemetry.addData("Target Vel", "fr (%.2f), rr (%.2f)", frontRightVelocity, rearRightVelocity);
             telemetry.addData("Power", "front left (%.2f), rear left (%.2f)", huskyBot.frontLeftDrive.getPower(), huskyBot.rearLeftDrive.getPower());
             telemetry.addData("Power", "front right (%.2f), rear right (%.2f)",  huskyBot.frontLeftDrive.getPower(), huskyBot.rearLeftDrive.getPower());
+
+            // Show the Arm/Claw Telemetry
+            telemetry.addData("Arm Swivel Power", "swv pwr (%.2f)", huskyBot.armSwivel.getPower());
+            telemetry.addData("Arm Length Power", "lgh pwr ($.2f)", huskyBot.armLength.getPower()); // This should only return -0.75 or 0.75
+            telemetry.addData("Arm Height Power", "ht pwr ($.2f)", huskyBot.armHeight.getPower());
 
             telemetry.update();
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -31,6 +31,7 @@ package org.firstinspires.ftc.teamcode;
 
 import static org.firstinspires.ftc.teamcode.HuskyBot.ARM_EXTENSION_MAX_POWER;
 import static org.firstinspires.ftc.teamcode.HuskyBot.ARM_LIFT_MAX_POWER;
+import static org.firstinspires.ftc.teamcode.HuskyBot.ARM_LIFT_POWER_AT_REST;
 import static org.firstinspires.ftc.teamcode.HuskyBot.ARM_SWIVEL_MAX_POWER;
 
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
@@ -100,32 +101,27 @@ public class HuskyTeleOpMode extends LinearOpMode {
             // todo + IMPORTANT: we will have to limit this to rotate only 240 degrees once the arm is added.
             armSwivelPower = -gamepad2.left_stick_x;
             armSwivelPower = Range.clip(armSwivelPower, -ARM_SWIVEL_MAX_POWER, ARM_SWIVEL_MAX_POWER);
-            if (armSwivelPower != 0) {
-                huskyBot.armSwivel.setPower(armSwivelPower);
-            }
+            huskyBot.armSwivel.setPower(armSwivelPower);
 
             armLiftPower = gamepad2.left_stick_y;
             // todo: this will have to be tuned for stability
             armLiftPower = Range.clip(armLiftPower, -ARM_LIFT_MAX_POWER, ARM_LIFT_MAX_POWER);
-            if (armLiftPower != 0) {
+            if (armLiftPower == 0) {
+                huskyBot.armLift.setPower(ARM_LIFT_POWER_AT_REST);
+            }
+            else {
                 huskyBot.armLift.setPower(armLiftPower);
             }
 
             // Increases/Decreases Arm Length
             armExtendPower = gamepad2.dpad_up ? ARM_EXTENSION_MAX_POWER : (gamepad2.dpad_down ? -ARM_EXTENSION_MAX_POWER : 0);
-            if (armExtendPower != 0) {
-                huskyBot.armExtend.setPower(armExtendPower);
-            }
+            huskyBot.armExtend.setPower(armExtendPower);
 
             clawRotationPosition = gamepad2.right_stick_x;
-            if (clawRotationPosition != 0) {
-                huskyBot.clawRotate.setPosition(clawRotationPosition);
-            }
+            huskyBot.clawRotate.setPosition(clawRotationPosition);
 
             clawLiftPosition = gamepad2.right_stick_y;
-            if (clawLiftPosition != 0) {
-                huskyBot.clawLift.setPosition(clawLiftPosition);
-            }
+            huskyBot.clawLift.setPosition(clawLiftPosition);
 
             if (gamepad2.x) {
                 huskyBot.clawGrab.setPosition(0.3);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -102,11 +102,11 @@ public class HuskyTeleOpMode extends LinearOpMode {
 
             // arm/claw mechanisms
             // todo + IMPORTANT: we will have to limit this to rotate only 240 degrees once the arm is added.
-            armSwivelPower = -gamepad2.left_stick_x;
+            armSwivelPower = gamepad2.left_stick_x/2;
             armSwivelPower = Range.clip(armSwivelPower, -ARM_SWIVEL_MAX_POWER, ARM_SWIVEL_MAX_POWER);
             huskyBot.armSwivel.setPower(armSwivelPower);
 
-            armLiftPower = gamepad2.left_stick_y;
+            armLiftPower = -gamepad2.left_stick_y/2;
             // todo: this will have to be tuned for stability
             armLiftPower = Range.clip(armLiftPower, -ARM_LIFT_MAX_POWER, ARM_LIFT_MAX_POWER);
             if (armLiftPower == 0) {
@@ -126,11 +126,9 @@ public class HuskyTeleOpMode extends LinearOpMode {
             if(gamepad2.right_stick_y > 0){
                 clawLiftPosition += 0.05;
             }
-            if(gamepad2.right_stick_y < 0)
-            {
+            if(gamepad2.right_stick_y < 0) {
                 clawLiftPosition -= 0.05;
             }
-            huskyBot.clawLift.setPosition(clawLiftPosition);
 
             if (gamepad2.x) {
                 huskyBot.clawGrab.setPosition(0.3);
@@ -140,16 +138,13 @@ public class HuskyTeleOpMode extends LinearOpMode {
             }
 
 
-            // todo: these *need* to be tuned
-            if(huskyBot.armLift.getPower() < 0)
+            // Dividing by four should account for the radius differences of both the spins, but it needs to be tested.
+            if(huskyBot.armLift.getPower() != 0)
             {
-                huskyBot.clawLift.setPosition(huskyBot.clawLift.getPosition() + 0.1);
+                clawLiftPosition = -huskyBot.armLift.getCurrentPosition()/4;
             }
 
-            if(huskyBot.armLift.getPower() > 0)
-            {
-                huskyBot.clawLift.setPosition(huskyBot.clawLift.getPosition() - 0.1);
-            }
+            huskyBot.clawLift.setPosition(clawLiftPosition);
 
             telemetry.addData("Status", "Run Time: " + runtime.toString());
             telemetry.addData("Stick", "y (%.2f), x (%.2f), rx (%.2f)", y, x, rx);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -92,6 +92,7 @@ public class HuskyTeleOpMode extends LinearOpMode {
 
             armAngle = 0.3 * (gamepad2.right_stick_x); // todo 0.3 will most likely have to be change
             armAngle = Range.clip(armAngle, -1, 1);
+            // todo + IMPORTANT: we will have to limit this to rotate only 360 degrees once the arm is added.
 
 
             double frontLeftVelocity = (y + x + rx) * HuskyBot.VELOCITY_CONSTANT;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -57,6 +57,8 @@ public class HuskyTeleOpMode extends LinearOpMode {
     double clawRotationPosition = 0.0;
     double clawLiftPosition = 0.0;
 
+    double MIN_ARM_POWER = 0.1;
+
     @Override
     public void runOpMode() {
         huskyBot.init(hardwareMap);
@@ -97,6 +99,7 @@ public class HuskyTeleOpMode extends LinearOpMode {
             huskyBot.frontRightDrive.setVelocity(frontRightVelocity);
             huskyBot.rearRightDrive.setVelocity(rearRightVelocity);
 
+
             // arm/claw mechanisms
             // todo + IMPORTANT: we will have to limit this to rotate only 240 degrees once the arm is added.
             armSwivelPower = -gamepad2.left_stick_x;
@@ -120,7 +123,13 @@ public class HuskyTeleOpMode extends LinearOpMode {
             clawRotationPosition = gamepad2.right_stick_x;
             huskyBot.clawRotate.setPosition(clawRotationPosition);
 
-            clawLiftPosition = gamepad2.right_stick_y;
+            if(gamepad2.right_stick_y > 0){
+                clawLiftPosition += 0.05;
+            }
+            if(gamepad2.right_stick_y < 0)
+            {
+                clawLiftPosition -= 0.05;
+            }
             huskyBot.clawLift.setPosition(clawLiftPosition);
 
             if (gamepad2.x) {
@@ -128,6 +137,18 @@ public class HuskyTeleOpMode extends LinearOpMode {
             }
             if (gamepad2.a) {
                 huskyBot.clawGrab.setPosition(0.0);
+            }
+
+
+            // todo: these *need* to be tuned
+            if(huskyBot.armLift.getPower() < 0)
+            {
+                huskyBot.clawLift.setPosition(huskyBot.clawLift.getPosition() + 0.1);
+            }
+
+            if(huskyBot.armLift.getPower() > 0)
+            {
+                huskyBot.clawLift.setPosition(huskyBot.clawLift.getPosition() - 0.1);
             }
 
             telemetry.addData("Status", "Run Time: " + runtime.toString());

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -96,11 +96,14 @@ public class HuskyTeleOpMode extends LinearOpMode {
             if(gamepad2.dpad_up)
             {
                 huskyBot.armLength.setPower(0.75);
+                // If this is right, then it will only move when the dpad is held, rather than a toggle button.
+                huskyBot.armLength.setPower(0);
             }
 
             if(gamepad2.dpad_down)
             {
                 huskyBot.armLength.setPower(-0.75);
+                huskyBot.armLength.setPower(0);
             }
 
             /*

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -35,8 +35,6 @@ import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.util.ElapsedTime;
 import com.qualcomm.robotcore.util.Range;
 
-import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
-
 @TeleOp(name = "Husky TeleOpMode", group = "TeleOp")
 public class HuskyTeleOpMode extends LinearOpMode {
 
@@ -90,8 +88,10 @@ public class HuskyTeleOpMode extends LinearOpMode {
             rx = Range.clip(rx, -1, 1);
             */
 
-            armAngle = 0.3 * (gamepad2.right_stick_x); // todo 0.3 will most likely have to be change
-            armAngle = Range.clip(armAngle, -1, 1);
+            huskyBot.armSwivel.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+            double armPower = -gamepad2.right_stick_x;
+            armPower = Range.clip(armPower, -0.1, 0.35);
+            huskyBot.armSwivel.setPower(armPower);
             // todo + IMPORTANT: we will have to limit this to rotate only 360 degrees once the arm is added.
 
 
@@ -100,16 +100,12 @@ public class HuskyTeleOpMode extends LinearOpMode {
             double frontRightVelocity = (y - x - rx) * HuskyBot.VELOCITY_CONSTANT;
             double rearRightVelocity = (y + x - rx) * HuskyBot.VELOCITY_CONSTANT;
 
-            double armSwivelVelocity = armAngle * HuskyBot.VELOCITY_CONSTANT;
-
             // apply the calculated values to the motors.
             huskyBot.frontLeftDrive.setVelocity(frontLeftVelocity);
             huskyBot.rearLeftDrive.setVelocity(rearLeftVelocity);
             huskyBot.frontRightDrive.setVelocity(frontRightVelocity);
             huskyBot.rearRightDrive.setVelocity(rearRightVelocity);
 
-            // apply the calculated arm values to the arm motor
-            huskyBot.armSwivelMotor.setVelocity(armSwivelVelocity);
 
             // Show the elapsed game time and wheel power.
             telemetry.addData("Status", "Run Time: " + runtime.toString());

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -59,7 +59,7 @@ public class HuskyTeleOpMode extends LinearOpMode {
         waitForStart();
         runtime.reset();
 
-        double y, x, rx;
+        double y, x, rx, armAngle;
 
         // run until the end of the match (driver presses STOP)
         while (opModeIsActive()) {
@@ -78,6 +78,8 @@ public class HuskyTeleOpMode extends LinearOpMode {
             x = gamepad1.left_stick_x;
             rx = gamepad1.right_stick_x;
 
+            /* This is commented out to test Gamepad 2 with Arm Movements
+               todo: change this for the final functions
             // this allows gamepad2 driver to drive the robot at a slower speed, to fine tune
             // the position of the robot when delivering the cargo
             y -= 0.3 * (gamepad2.left_stick_y);
@@ -86,17 +88,27 @@ public class HuskyTeleOpMode extends LinearOpMode {
             x = Range.clip(x, -1, 1);
             rx += 0.3 * (gamepad2.right_stick_x);
             rx = Range.clip(rx, -1, 1);
+            */
+
+            armAngle = 0.3 * (gamepad2.right_stick_x); // todo 0.3 will most likely have to be change
+            armAngle = Range.clip(armAngle, -1, 1);
+
 
             double frontLeftVelocity = (y + x + rx) * HuskyBot.VELOCITY_CONSTANT;
             double rearLeftVelocity = (y - x + rx) * HuskyBot.VELOCITY_CONSTANT;
             double frontRightVelocity = (y - x - rx) * HuskyBot.VELOCITY_CONSTANT;
             double rearRightVelocity = (y + x - rx) * HuskyBot.VELOCITY_CONSTANT;
 
+            double armSwivelVelocity = armAngle * HuskyBot.VELOCITY_CONSTANT;
+
             // apply the calculated values to the motors.
             huskyBot.frontLeftDrive.setVelocity(frontLeftVelocity);
             huskyBot.rearLeftDrive.setVelocity(rearLeftVelocity);
             huskyBot.frontRightDrive.setVelocity(frontRightVelocity);
             huskyBot.rearRightDrive.setVelocity(rearRightVelocity);
+
+            // apply the calculated arm values to the arm motor
+            huskyBot.armSwivelMotor.setVelocity(armSwivelVelocity);
 
             // Show the elapsed game time and wheel power.
             telemetry.addData("Status", "Run Time: " + runtime.toString());


### PR DESCRIPTION
Changed clawLift Position to be set to the inverse of the armLift Position, which should keep it in equilibrium. The controls for arm lift and arm swivel were inverted, so I inverted them again, and also reduced the power of arm swivel and arm lift by 1/2, which should improve stability. After testing today, if we can reduce the factor of 1/2 to something else and still be stable, I will change it to that. 