### PR TITLE
Remove uneeded import in FtcOpModeRegister.java

### DIFF
--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcOpModeRegister.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcOpModeRegister.java
@@ -34,8 +34,6 @@ package org.firstinspires.ftc.robotcontroller.internal;
 import com.qualcomm.robotcore.eventloop.opmode.OpModeManager;
 import com.qualcomm.robotcore.eventloop.opmode.OpModeRegister;
 
-import org.firstinspires.ftc.robotcontroller.external.samples.ConceptNullOp;
-
 /**
  * {@link FtcOpModeRegister} is responsible for registering OpModes for use in an FTC game.
  * @see #register(OpModeManager)
@@ -49,7 +47,7 @@ public class FtcOpModeRegister implements OpModeRegister {
      * There are two mechanisms by which an OpMode may be registered.
      *
      *  1) The preferred method is by means of class annotations in the OpMode itself.
-     *  See, for example the class annotations in {@link ConceptNullOp}.
+     *  See, for example the class annotations in {@link org.firstinspires.ftc.robotcontroller.external.samples.ConceptNullOp}.
      *
      *  2) The other, retired,  method is to modify this {@link #register(OpModeManager)}
      *  method to include explicit calls to OpModeManager.register().


### PR DESCRIPTION
Yes, this is intended to be an actual PR, and is not a mistake.

See https://github.com/FIRST-Tech-Challenge/FtcRobotController/issues/383#issuecomment-1587666689

Closes https://github.com/FIRST-Tech-Challenge/FtcRobotController/issues/383 (as all the other listed issues have been fixed.)
