### PR TITLE
Update build.gradle with correct gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
     dependencies {
         // Note for FTC Teams: Do not modify this yourself.
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:7.4.0'
     }
 }
 


### PR DESCRIPTION
fixes gradle version that is incompatable with new Android studio installs in build.gradle

Before issuing a pull request, please see the contributing page.
