### PR TITLE
Add X-drive TeleOp with intake, index and shooter controls

### DIFF
--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -25,4 +25,8 @@ android {
 
 dependencies {
     implementation project(':FtcRobotController')
+
+    // FTCLib command-based framework (subsystems, commands, GamepadEx button bindings).
+    // Only the 'core' module - we do not use FTCLib's vision module.
+    implementation 'org.ftclib.ftclib:core:2.1.1'
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConstants.java
@@ -1,0 +1,84 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
+import com.qualcomm.robotcore.hardware.DcMotor;
+
+/**
+ * Every number worth tuning, in one place.
+ *
+ * These are deliberately {@code public static} and NOT {@code final} so that FTC Dashboard's
+ * {@code @Config} annotation can be added to this class later to tune them live from the pit,
+ * without having to restructure anything.
+ */
+public class RobotConstants {
+
+    // ---------------------------------------------------------------------------------------
+    // Hardware configuration names - these must match the configuration on the Driver Station
+    // ---------------------------------------------------------------------------------------
+    public static final String INTAKE_NAME        = "intake";         // M1
+    public static final String INDEX_NAME         = "index";          // M2
+    public static final String SHOOTER_LEFT_NAME  = "shooter_left";   // M3
+    public static final String SHOOTER_RIGHT_NAME = "shooter_right";  // M4
+
+    // ---------------------------------------------------------------------------------------
+    // Mechanism speeds - reverse directions use the negative of these same numbers
+    // ---------------------------------------------------------------------------------------
+
+    /** M1 forward. Negated for outtake. */
+    public static double INTAKE_POWER = 0.8;
+
+    /** M2 forward. Negated to run the index backwards. */
+    public static double INDEX_POWER = 1.0;
+
+    /** M3 and M4 for a close shot. Placeholder - tune this on the field. */
+    public static double CLOSE_SHOOT_SPEED = 0.7;
+
+    /** M3 and M4 for a far shot. Placeholder - tune this on the field. */
+    public static double FAR_SHOOT_SPEED = 1.0;
+
+    // ---------------------------------------------------------------------------------------
+    // Motor directions
+    // ---------------------------------------------------------------------------------------
+    public static final DcMotor.Direction INTAKE_DIRECTION = DcMotor.Direction.FORWARD;
+    public static final DcMotor.Direction INDEX_DIRECTION  = DcMotor.Direction.FORWARD;
+
+    /**
+     * Both shooter wheels have to throw the ball the same way. Depending on how M3 and M4 are
+     * mounted, one of them will probably need to be REVERSE - if the wheels fight each other on
+     * the first test, flip this one.
+     */
+    public static final DcMotor.Direction SHOOTER_LEFT_DIRECTION  = DcMotor.Direction.FORWARD;
+    public static final DcMotor.Direction SHOOTER_RIGHT_DIRECTION = DcMotor.Direction.FORWARD;
+
+    // ---------------------------------------------------------------------------------------
+    // Driving
+    // ---------------------------------------------------------------------------------------
+
+    /** Stick movement smaller than this counts as zero, so a worn stick doesn't creep. */
+    public static double DEADBAND = 0.05;
+
+    /** Turning is scaled down separately - full-power turns are hard to control. */
+    public static double TURN_SCALE = 0.8;
+
+    /**
+     * Slow-speed multiplier. Currently not bound to any button, because Y, X and the D-pad are
+     * being held for the Limelight controls. Binding it later is one line in CompTeleOp.
+     */
+    public static double PRECISION_SPEED = 0.35;
+
+    /** How far a trigger must be pulled before it counts as pressed. */
+    public static double TRIGGER_THRESHOLD = 0.5;
+
+    // ---------------------------------------------------------------------------------------
+    // Control Hub mounting - change these to match how the hub sits on the robot,
+    // or field-centric drive will read the heading off the wrong axis.
+    // ---------------------------------------------------------------------------------------
+    public static final RevHubOrientationOnRobot.LogoFacingDirection LOGO_DIRECTION =
+            RevHubOrientationOnRobot.LogoFacingDirection.UP;
+    public static final RevHubOrientationOnRobot.UsbFacingDirection USB_DIRECTION =
+            RevHubOrientationOnRobot.UsbFacingDirection.FORWARD;
+
+    private RobotConstants() {
+        // Constants holder - not meant to be instantiated.
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/DriveCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/DriveCommand.java
@@ -1,0 +1,58 @@
+package org.firstinspires.ftc.teamcode.commands;
+
+import com.arcrobotics.ftclib.command.CommandBase;
+import com.arcrobotics.ftclib.gamepad.GamepadEx;
+
+import org.firstinspires.ftc.teamcode.RobotConstants;
+import org.firstinspires.ftc.teamcode.subsystems.DrivebaseSubsystem;
+
+/**
+ * The drivebase's default command: reads the sticks every loop and drives field-centric.
+ *
+ * This never finishes, so it runs the whole match unless something else claims the drivebase.
+ */
+public class DriveCommand extends CommandBase {
+
+    private final DrivebaseSubsystem drivebase;
+    private final GamepadEx driver;
+
+    public DriveCommand(DrivebaseSubsystem drivebase, GamepadEx driver) {
+        this.drivebase = drivebase;
+        this.driver = driver;
+        addRequirements(drivebase);
+    }
+
+    @Override
+    public void execute() {
+        // GamepadEx.getLeftY() already flips the stick, so pushing forward gives a positive number.
+        double forward = shape(driver.getLeftY());
+        double right   = shape(driver.getLeftX());
+        double rotate  = shape(driver.getRightX()) * RobotConstants.TURN_SCALE;
+
+        drivebase.driveFieldCentric(forward, right, rotate);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        drivebase.stop();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    /**
+     * Removes the deadband and squares the stick input. Squaring keeps full power available at the
+     * end of the stick's travel while making small movements much gentler.
+     */
+    private double shape(double input) {
+        double magnitude = Math.abs(input);
+        if (magnitude < RobotConstants.DEADBAND) {
+            return 0.0;
+        }
+        // Rescale so the robot starts moving right at the edge of the deadband rather than jumping.
+        double scaled = (magnitude - RobotConstants.DEADBAND) / (1.0 - RobotConstants.DEADBAND);
+        return Math.signum(input) * scaled * scaled;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/XDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/XDrive.java
@@ -1,0 +1,153 @@
+package org.firstinspires.ftc.teamcode.drive;
+
+import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+import com.qualcomm.robotcore.hardware.IMU;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+
+/**
+ * Drivetrain for a four-wheel X-drive (four omni wheels at the corners, each mounted at 45 degrees
+ * so that its axle points at the center of the chassis).
+ *
+ * Because each wheel pushes along a 45-degree diagonal, an X-drive uses the same power mixing as a
+ * mecanum drive: the front-left and back-right wheels push forward-and-right, the front-right and
+ * back-left wheels push forward-and-left. Unlike mecanum, an X-drive gets that diagonal from the
+ * mounting angle instead of from angled rollers, so there is no roller scrub and the wheels rotate
+ * the robot purely tangentially.
+ *
+ * All three inputs (forward, right, rotate) are in the range -1.0 to +1.0.
+ */
+public class XDrive {
+
+    // ---------------------------------------------------------------------------------------
+    // Configuration - these names must match the robot configuration file on the Driver Station
+    // ---------------------------------------------------------------------------------------
+    public static final String FRONT_LEFT_NAME  = "front_left_drive";
+    public static final String FRONT_RIGHT_NAME = "front_right_drive";
+    public static final String BACK_LEFT_NAME   = "back_left_drive";
+    public static final String BACK_RIGHT_NAME  = "back_right_drive";
+    public static final String IMU_NAME         = "imu";
+
+    /**
+     * Motor directions. The left side is reversed here because on most builds the left motors face
+     * the opposite way from the right ones. If the robot spins instead of driving forward, flip the
+     * direction of whichever pair is fighting the others.
+     */
+    private static final DcMotor.Direction FRONT_LEFT_DIRECTION  = DcMotor.Direction.REVERSE;
+    private static final DcMotor.Direction BACK_LEFT_DIRECTION   = DcMotor.Direction.REVERSE;
+    private static final DcMotor.Direction FRONT_RIGHT_DIRECTION = DcMotor.Direction.FORWARD;
+    private static final DcMotor.Direction BACK_RIGHT_DIRECTION  = DcMotor.Direction.FORWARD;
+
+    private final DcMotorEx frontLeft;
+    private final DcMotorEx frontRight;
+    private final DcMotorEx backLeft;
+    private final DcMotorEx backRight;
+    private final IMU imu;
+
+    /** Scales every wheel power. 1.0 is full speed; lower it for precision driving or demos. */
+    private double speedScale = 1.0;
+
+    /**
+     * @param hardwareMap   the OpMode's hardwareMap
+     * @param logoDirection which way the Control Hub's REV logo points on the robot
+     * @param usbDirection  which way the Control Hub's USB ports point on the robot
+     */
+    public XDrive(HardwareMap hardwareMap,
+                  RevHubOrientationOnRobot.LogoFacingDirection logoDirection,
+                  RevHubOrientationOnRobot.UsbFacingDirection usbDirection) {
+
+        frontLeft  = hardwareMap.get(DcMotorEx.class, FRONT_LEFT_NAME);
+        frontRight = hardwareMap.get(DcMotorEx.class, FRONT_RIGHT_NAME);
+        backLeft   = hardwareMap.get(DcMotorEx.class, BACK_LEFT_NAME);
+        backRight  = hardwareMap.get(DcMotorEx.class, BACK_RIGHT_NAME);
+
+        frontLeft.setDirection(FRONT_LEFT_DIRECTION);
+        frontRight.setDirection(FRONT_RIGHT_DIRECTION);
+        backLeft.setDirection(BACK_LEFT_DIRECTION);
+        backRight.setDirection(BACK_RIGHT_DIRECTION);
+
+        for (DcMotorEx motor : new DcMotorEx[] {frontLeft, frontRight, backLeft, backRight}) {
+            // Brake makes the robot stop where you let go of the stick instead of coasting.
+            motor.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+            // RUN_USING_ENCODER holds a commanded velocity, which keeps the four wheels matched.
+            // If your drive motors have no encoder cables, change this to RUN_WITHOUT_ENCODER.
+            motor.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+            motor.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        }
+
+        imu = hardwareMap.get(IMU.class, IMU_NAME);
+        imu.initialize(new IMU.Parameters(new RevHubOrientationOnRobot(logoDirection, usbDirection)));
+        imu.resetYaw();
+    }
+
+    /**
+     * Drives from the robot's point of view: +forward is out the front of the robot no matter which
+     * way the robot is pointing.
+     */
+    public void driveRobotCentric(double forward, double right, double rotate) {
+        // X-drive mixing. Each wheel gets the projection of the requested motion onto its own
+        // 45-degree push direction, plus its share of the rotation.
+        double frontLeftPower  = forward + right + rotate;
+        double frontRightPower = forward - right - rotate;
+        double backLeftPower   = forward - right + rotate;
+        double backRightPower  = forward + right - rotate;
+
+        // If any wheel would exceed full power, scale all four down together. Clipping them
+        // individually instead would bend the robot off the direction the driver asked for.
+        double largest = Math.max(1.0, Math.max(
+                Math.max(Math.abs(frontLeftPower), Math.abs(frontRightPower)),
+                Math.max(Math.abs(backLeftPower), Math.abs(backRightPower))));
+
+        frontLeft.setPower(speedScale * frontLeftPower / largest);
+        frontRight.setPower(speedScale * frontRightPower / largest);
+        backLeft.setPower(speedScale * backLeftPower / largest);
+        backRight.setPower(speedScale * backRightPower / largest);
+    }
+
+    /**
+     * Drives from the driver's point of view: pushing the stick away from you sends the robot away
+     * from you, whatever direction the robot happens to be facing. Rotation is unaffected.
+     */
+    public void driveFieldCentric(double forward, double right, double rotate) {
+        double heading = getHeading(AngleUnit.RADIANS);
+
+        // Rotate the requested translation backwards by the robot's heading, so that a field
+        // direction becomes the equivalent robot direction.
+        double cos = Math.cos(heading);
+        double sin = Math.sin(heading);
+        double robotForward = forward * cos - right * sin;
+        double robotRight   = right * cos + forward * sin;
+
+        driveRobotCentric(robotForward, robotRight, rotate);
+    }
+
+    /** Cuts all motor power. */
+    public void stop() {
+        driveRobotCentric(0, 0, 0);
+    }
+
+    /**
+     * Tells field-centric drive that the robot is currently pointing "away from the driver".
+     * Call this at the start of TeleOp and any time the heading drifts.
+     */
+    public void resetYaw() {
+        imu.resetYaw();
+    }
+
+    /** Current robot heading, counter-clockwise positive, measured from the last yaw reset. */
+    public double getHeading(AngleUnit unit) {
+        return imu.getRobotYawPitchRollAngles().getYaw(unit);
+    }
+
+    /** @param scale 0.0 to 1.0 - multiplies every wheel power. */
+    public void setSpeedScale(double scale) {
+        speedScale = Math.max(0.0, Math.min(1.0, scale));
+    }
+
+    public double getSpeedScale() {
+        return speedScale;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/CompTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/CompTeleOp.java
@@ -1,0 +1,118 @@
+package org.firstinspires.ftc.teamcode.opmodes;
+
+import com.arcrobotics.ftclib.command.CommandOpMode;
+import com.arcrobotics.ftclib.command.CommandScheduler;
+import com.arcrobotics.ftclib.command.StartEndCommand;
+import com.arcrobotics.ftclib.command.button.GamepadButton;
+import com.arcrobotics.ftclib.command.button.Trigger;
+import com.arcrobotics.ftclib.gamepad.GamepadEx;
+import com.arcrobotics.ftclib.gamepad.GamepadKeys;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.firstinspires.ftc.teamcode.RobotConstants;
+import org.firstinspires.ftc.teamcode.commands.DriveCommand;
+import org.firstinspires.ftc.teamcode.subsystems.DrivebaseSubsystem;
+import org.firstinspires.ftc.teamcode.subsystems.IndexSubsystem;
+import org.firstinspires.ftc.teamcode.subsystems.IntakeSubsystem;
+import org.firstinspires.ftc.teamcode.subsystems.ShooterSubsystem;
+
+/**
+ * Competition TeleOp. Everything is on gamepad 1.
+ *
+ *   left stick      drive and strafe (field-centric)
+ *   right stick x   turn
+ *
+ *   right bumper    index forward, feeds balls to the shooter
+ *   left bumper     index backwards, clears a jam
+ *   right trigger   intake
+ *   left trigger    outtake
+ *   B / circle      shooter at far speed
+ *   A / cross       shooter at close speed
+ *
+ * All six mechanism controls are hold-to-run: the motor spins while you hold the button and stops
+ * the moment you let go. Shooting and feeding are separate, so to fire you hold B (or A) to get the
+ * wheels up to speed, then hold the right bumper to feed a ball into them.
+ *
+ * Y, X and the D-pad are deliberately left unbound - they are reserved for the Limelight controls.
+ */
+@TeleOp(name = "Comp TeleOp", group = "Drive")
+public class CompTeleOp extends CommandOpMode {
+
+    private DrivebaseSubsystem drivebase;
+    private IntakeSubsystem intake;
+    private IndexSubsystem index;
+    private ShooterSubsystem shooter;
+
+    @Override
+    public void initialize() {
+        // Clear anything left over from a previous OpMode run before registering new subsystems.
+        CommandScheduler.getInstance().reset();
+
+        drivebase = new DrivebaseSubsystem(hardwareMap);
+        intake    = new IntakeSubsystem(hardwareMap);
+        index     = new IndexSubsystem(hardwareMap);
+        shooter   = new ShooterSubsystem(hardwareMap);
+
+        GamepadEx driver = new GamepadEx(gamepad1);
+
+        // Driving runs continuously in the background whenever nothing else claims the drivebase.
+        drivebase.setDefaultCommand(new DriveCommand(drivebase, driver));
+
+        // --- Index: right bumper feeds, left bumper clears ---
+        new GamepadButton(driver, GamepadKeys.Button.RIGHT_BUMPER)
+                .whenHeld(new StartEndCommand(index::forward, index::stop, index));
+
+        new GamepadButton(driver, GamepadKeys.Button.LEFT_BUMPER)
+                .whenHeld(new StartEndCommand(index::reverse, index::stop, index));
+
+        // --- Intake: triggers are analog, so they need a threshold rather than a button press ---
+        new Trigger(() -> driver.getTrigger(GamepadKeys.Trigger.RIGHT_TRIGGER)
+                > RobotConstants.TRIGGER_THRESHOLD)
+                .whileActiveOnce(new StartEndCommand(intake::intake, intake::stop, intake));
+
+        new Trigger(() -> driver.getTrigger(GamepadKeys.Trigger.LEFT_TRIGGER)
+                > RobotConstants.TRIGGER_THRESHOLD)
+                .whileActiveOnce(new StartEndCommand(intake::outtake, intake::stop, intake));
+
+        // --- Shooter: B is the far shot, A is the close shot ---
+        new GamepadButton(driver, GamepadKeys.Button.B)
+                .whenHeld(new StartEndCommand(shooter::shootFar, shooter::stop, shooter));
+
+        new GamepadButton(driver, GamepadKeys.Button.A)
+                .whenHeld(new StartEndCommand(shooter::shootClose, shooter::stop, shooter));
+
+        telemetry.addLine("Ready.");
+        telemetry.addLine("Point the robot away from the driver station before pressing START -");
+        telemetry.addLine("that heading becomes 'forward' and there is no reset button.");
+        telemetry.update();
+    }
+
+    /**
+     * Same loop as {@link CommandOpMode}, with two additions: the heading is zeroed the instant the
+     * match starts (so the robot can be re-aimed between INIT and START), and telemetry is updated
+     * every cycle.
+     */
+    @Override
+    public void runOpMode() throws InterruptedException {
+        initialize();
+
+        waitForStart();
+
+        drivebase.resetYaw();
+
+        while (!isStopRequested() && opModeIsActive()) {
+            run();
+
+            telemetry.addData("Heading", "%.1f deg", drivebase.getHeading(AngleUnit.DEGREES));
+            telemetry.addData("Intake (M1)", "%.2f", intake.getPower());
+            telemetry.addData("Index (M2)", "%.2f", index.getPower());
+            telemetry.addData("Shooter (M3/M4)", "%.2f", shooter.getPower());
+            telemetry.addData("Shooter ticks/sec", "%.0f / %.0f",
+                    shooter.getLeftVelocity(), shooter.getRightVelocity());
+            telemetry.update();
+        }
+
+        reset();
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/DrivebaseSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/DrivebaseSubsystem.java
@@ -1,0 +1,52 @@
+package org.firstinspires.ftc.teamcode.subsystems;
+
+import com.arcrobotics.ftclib.command.SubsystemBase;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.firstinspires.ftc.teamcode.RobotConstants;
+import org.firstinspires.ftc.teamcode.drive.XDrive;
+
+/**
+ * The X-drive drivetrain, wrapped as a command-based subsystem.
+ *
+ * All of the real work - the X-drive wheel mixing, power normalization and IMU handling - lives in
+ * {@link XDrive}. This class only exists to let the scheduler own the drivetrain so it can run a
+ * default command and resolve conflicts between commands that want to drive.
+ */
+public class DrivebaseSubsystem extends SubsystemBase {
+
+    private final XDrive drive;
+
+    public DrivebaseSubsystem(HardwareMap hardwareMap) {
+        drive = new XDrive(hardwareMap, RobotConstants.LOGO_DIRECTION, RobotConstants.USB_DIRECTION);
+    }
+
+    /** Drives from the driver's point of view, using the heading captured at start. */
+    public void driveFieldCentric(double forward, double right, double rotate) {
+        drive.driveFieldCentric(forward, right, rotate);
+    }
+
+    /** Drives from the robot's point of view. Not currently bound to anything. */
+    public void driveRobotCentric(double forward, double right, double rotate) {
+        drive.driveRobotCentric(forward, right, rotate);
+    }
+
+    public void stop() {
+        drive.stop();
+    }
+
+    /** Sets the current heading as "away from the driver" for field-centric drive. */
+    public void resetYaw() {
+        drive.resetYaw();
+    }
+
+    public double getHeading(AngleUnit unit) {
+        return drive.getHeading(unit);
+    }
+
+    /** @param scale 0.0 to 1.0 - multiplies every wheel power. */
+    public void setSpeedScale(double scale) {
+        drive.setSpeedScale(scale);
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/IndexSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/IndexSubsystem.java
@@ -1,0 +1,39 @@
+package org.firstinspires.ftc.teamcode.subsystems;
+
+import com.arcrobotics.ftclib.command.SubsystemBase;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+import org.firstinspires.ftc.teamcode.RobotConstants;
+
+/** M2 - the index that moves balls from the intake up to the shooter. */
+public class IndexSubsystem extends SubsystemBase {
+
+    private final DcMotorEx motor;
+
+    public IndexSubsystem(HardwareMap hardwareMap) {
+        motor = hardwareMap.get(DcMotorEx.class, RobotConstants.INDEX_NAME);
+        motor.setDirection(RobotConstants.INDEX_DIRECTION);
+        motor.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+        motor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+    }
+
+    /** Feeds balls toward the shooter. */
+    public void forward() {
+        motor.setPower(RobotConstants.INDEX_POWER);
+    }
+
+    /** Runs the index backwards - the same speed, negated. Use this to clear a jam. */
+    public void reverse() {
+        motor.setPower(-RobotConstants.INDEX_POWER);
+    }
+
+    public void stop() {
+        motor.setPower(0);
+    }
+
+    public double getPower() {
+        return motor.getPower();
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/IntakeSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/IntakeSubsystem.java
@@ -1,0 +1,39 @@
+package org.firstinspires.ftc.teamcode.subsystems;
+
+import com.arcrobotics.ftclib.command.SubsystemBase;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+import org.firstinspires.ftc.teamcode.RobotConstants;
+
+/** M1 - the intake roller that pulls balls into the robot. */
+public class IntakeSubsystem extends SubsystemBase {
+
+    private final DcMotorEx motor;
+
+    public IntakeSubsystem(HardwareMap hardwareMap) {
+        motor = hardwareMap.get(DcMotorEx.class, RobotConstants.INTAKE_NAME);
+        motor.setDirection(RobotConstants.INTAKE_DIRECTION);
+        motor.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.FLOAT);
+        motor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+    }
+
+    /** Pulls balls in. */
+    public void intake() {
+        motor.setPower(RobotConstants.INTAKE_POWER);
+    }
+
+    /** Spits balls back out - the same speed, reversed. */
+    public void outtake() {
+        motor.setPower(-RobotConstants.INTAKE_POWER);
+    }
+
+    public void stop() {
+        motor.setPower(0);
+    }
+
+    public double getPower() {
+        return motor.getPower();
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ShooterSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ShooterSubsystem.java
@@ -1,0 +1,68 @@
+package org.firstinspires.ftc.teamcode.subsystems;
+
+import com.arcrobotics.ftclib.command.SubsystemBase;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+import org.firstinspires.ftc.teamcode.RobotConstants;
+
+/**
+ * M3 and M4 - the two shooter wheels. They always run together at the same power, so the whole
+ * shooter is treated as one subsystem rather than two.
+ */
+public class ShooterSubsystem extends SubsystemBase {
+
+    private final DcMotorEx leftMotor;
+    private final DcMotorEx rightMotor;
+
+    public ShooterSubsystem(HardwareMap hardwareMap) {
+        leftMotor  = hardwareMap.get(DcMotorEx.class, RobotConstants.SHOOTER_LEFT_NAME);
+        rightMotor = hardwareMap.get(DcMotorEx.class, RobotConstants.SHOOTER_RIGHT_NAME);
+
+        leftMotor.setDirection(RobotConstants.SHOOTER_LEFT_DIRECTION);
+        rightMotor.setDirection(RobotConstants.SHOOTER_RIGHT_DIRECTION);
+
+        for (DcMotorEx motor : new DcMotorEx[] {leftMotor, rightMotor}) {
+            // FLOAT, not BRAKE - braking a flywheel this heavy every time you let go of the
+            // button wears the motors out for no benefit. Let it spin down on its own.
+            motor.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.FLOAT);
+            motor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+        }
+    }
+
+    /** Runs both wheels at the given power, -1.0 to 1.0. */
+    public void shootAt(double power) {
+        leftMotor.setPower(power);
+        rightMotor.setPower(power);
+    }
+
+    public void shootClose() {
+        shootAt(RobotConstants.CLOSE_SHOOT_SPEED);
+    }
+
+    public void shootFar() {
+        shootAt(RobotConstants.FAR_SHOOT_SPEED);
+    }
+
+    public void stop() {
+        shootAt(0);
+    }
+
+    public double getPower() {
+        return leftMotor.getPower();
+    }
+
+    /**
+     * Current wheel speeds in encoder ticks per second. Only meaningful if the shooter motors
+     * have encoder cables plugged in - useful for checking the wheels are up to speed before
+     * feeding a ball, and the starting point if you add closed-loop velocity control later.
+     */
+    public double getLeftVelocity() {
+        return leftMotor.getVelocity();
+    }
+
+    public double getRightVelocity() {
+        return rightMotor.getVelocity();
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/XDriveTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/XDriveTeleOp.java
@@ -1,0 +1,116 @@
+package org.firstinspires.ftc.teamcode.teleop;
+
+import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.firstinspires.ftc.teamcode.drive.XDrive;
+
+/**
+ * Driver-controlled OpMode for an X-drive robot.
+ *
+ * Gamepad 1:
+ *   left stick          drive and strafe
+ *   right stick (x)     turn
+ *   left bumper (hold)  precision mode - everything moves slowly for lining up
+ *   right bumper (hold) robot-centric override, like driving an RC car
+ *   Y                   toggle field-centric drive on/off
+ *   A                   set the current heading as "forward" for field-centric drive
+ */
+@TeleOp(name = "X-Drive TeleOp (drive only)", group = "Drive")
+@Disabled  // Superseded by CompTeleOp. Kept as a plain-SDK reference - delete @Disabled to use it.
+public class XDriveTeleOp extends LinearOpMode {
+
+    /**
+     * How the Control Hub is mounted on the robot. Change these two to match your build, or
+     * field-centric drive will read the heading off the wrong axis.
+     */
+    private static final RevHubOrientationOnRobot.LogoFacingDirection LOGO_DIRECTION =
+            RevHubOrientationOnRobot.LogoFacingDirection.UP;
+    private static final RevHubOrientationOnRobot.UsbFacingDirection USB_DIRECTION =
+            RevHubOrientationOnRobot.UsbFacingDirection.FORWARD;
+
+    /** Stick movement smaller than this is treated as zero, so a worn stick doesn't creep. */
+    private static final double DEADBAND = 0.05;
+
+    private static final double NORMAL_SPEED    = 1.0;
+    private static final double PRECISION_SPEED = 0.35;
+
+    /** Turning is scaled down separately - full-power turns are hard to control. */
+    private static final double TURN_SCALE = 0.8;
+
+    private boolean fieldCentric = true;
+
+    @Override
+    public void runOpMode() {
+        XDrive drive = new XDrive(hardwareMap, LOGO_DIRECTION, USB_DIRECTION);
+
+        telemetry.addLine("X-Drive ready.");
+        telemetry.addLine("Point the robot away from the driver station before starting.");
+        telemetry.update();
+
+        waitForStart();
+
+        // Whatever direction the robot is pointing at the start becomes "forward" for the driver.
+        drive.resetYaw();
+
+        boolean previousY = false;
+        boolean previousA = false;
+
+        while (opModeIsActive()) {
+            // Stick y is negative when pushed forward, so flip it.
+            double forward = shape(-gamepad1.left_stick_y);
+            double right   = shape(gamepad1.left_stick_x);
+            double rotate  = shape(gamepad1.right_stick_x) * TURN_SCALE;
+
+            drive.setSpeedScale(gamepad1.left_bumper ? PRECISION_SPEED : NORMAL_SPEED);
+
+            // Rising-edge checks so holding a button only counts once.
+            if (gamepad1.y && !previousY) {
+                fieldCentric = !fieldCentric;
+            }
+            if (gamepad1.a && !previousA) {
+                drive.resetYaw();
+            }
+            previousY = gamepad1.y;
+            previousA = gamepad1.a;
+
+            // The right bumper temporarily forces robot-centric driving, which is the quickest way
+            // out of trouble if the heading gets confused mid-match.
+            boolean useFieldCentric = fieldCentric && !gamepad1.right_bumper;
+
+            if (useFieldCentric) {
+                drive.driveFieldCentric(forward, right, rotate);
+            } else {
+                drive.driveRobotCentric(forward, right, rotate);
+            }
+
+            telemetry.addData("Mode", useFieldCentric ? "Field-centric" : "Robot-centric");
+            telemetry.addData("Speed", gamepad1.left_bumper ? "Precision" : "Normal");
+            telemetry.addData("Heading", "%.1f deg", drive.getHeading(AngleUnit.DEGREES));
+            telemetry.addLine();
+            telemetry.addData("Drive", "fwd %.2f  right %.2f  turn %.2f", forward, right, rotate);
+            telemetry.addLine("Y: toggle field-centric   A: reset heading");
+            telemetry.addLine("LB: precision   RB: hold for robot-centric");
+            telemetry.update();
+        }
+
+        drive.stop();
+    }
+
+    /**
+     * Removes the deadband and squares the stick input. Squaring keeps full power available at the
+     * end of the stick's travel while making small movements much gentler.
+     */
+    private double shape(double input) {
+        double magnitude = Math.abs(input);
+        if (magnitude < DEADBAND) {
+            return 0.0;
+        }
+        // Rescale so the robot starts moving right at the edge of the deadband rather than jumping.
+        double scaled = (magnitude - DEADBAND) / (1.0 - DEADBAND);
+        return Math.signum(input) * scaled * scaled;
+    }
+}


### PR DESCRIPTION
Adds the team's robot code on top of the FTC SDK: an X-drive drivetrain and driver controls for the four mechanism motors (M1 intake, M2 index, M3/M4 shooter).

Structured as FTCLib command-based subsystems and commands, matching the structure the team already uses elsewhere. XDrive holds the raw kinematics and IMU handling; DrivebaseSubsystem wraps it so the scheduler can own the drivetrain and run DriveCommand as its default command.

All six mechanism controls are hold-to-run via StartEndCommand, so a motor stops the moment its button is released. Y, X and the D-pad are left deliberately unbound, reserved for Limelight controls later.

Field-centric drive zeroes its heading at START rather than INIT, so the robot can be re-aimed after initializing. There is no mid-match reset button, by design.

Every tunable speed lives in RobotConstants as non-final statics, so FTC Dashboard's @Config can be added later without restructuring. Close and far shooter speeds are placeholders pending on-field tuning.

Also adds the FTCLib core dependency and disables the older drive-only TeleOp, which is kept as a plain-SDK reference.

Before issuing a pull request, please see the contributing page.
